### PR TITLE
Default influx config values contained underscores which made them ignored

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -58,7 +58,7 @@ spec:
       containers:
         - name: influxdata-operator
           # Replace this with the built image name
-          image: REPLACE_IMAGE
+          image: REPLACE-IMAGE
           ports:
           - containerPort: 60000
             name: metrics
@@ -143,116 +143,116 @@ metadata:
     app: influxdb
 data:
   influxdb.conf: |+
-    reporting_disabled = false
-    bind_address = "127.0.0.1:8088"
-    storage_directory = "/var/lib/influxdb"
+    reporting-disabled = false
+    bind-address = "127.0.0.1:8088"
+    storage-directory = "/var/lib/influxdb"
     [meta]
       dir = "/var/lib/influxdb/meta"
-      retention_autocreate = true
-      logging_enabled = true
+      retention-autocreate = true
+      logging-enabled = true
     [data]
       dir = "/var/lib/influxdb/data"
       wal-dir = "/var/lib/influxdb/wal"
-      query_log_enabled = true
-      cache_max_memory_size = 1073741824
-      cache_snapshot_memory_size = 26214400
-      cache_snapshot_write_cold_duration = "10m0s"
-      compact_full_write_cold_duration = "4h0m0s"
-      max_series_per_database = 1000000
-      max_values_per_tag = 100000
-      trace_logging_enabled = false
+      query-log-enabled = true
+      cache-max-memory-size = 1073741824
+      cache-snapshot-memory-size = 26214400
+      cache-snapshot-write-cold-duration = "10m0s"
+      compact-full-write-cold-duration = "4h0m0s"
+      max-series-per-database = 1000000
+      max-values-per-tag = 100000
+      trace-logging-enabled = false
     [coordinator]
-      write_timeout = "10s"
-      max_concurrent_queries = 0
-      query_timeout = "0s"
-      log_queries_after = "0s"
-      max_select_point = 0
-      max_select_series = 0
-      max_select_buckets = 0
+      write-timeout = "10s"
+      max-concurrent-queries = 0
+      query-timeout = "0s"
+      log-queries-after = "0s"
+      max-select-point = 0
+      max-select-series = 0
+      max-select-buckets = 0
     [retention]
       enabled = true
-      check_interval = "30m0s"
-    [shard_precreation]
+      check-interval = "30m0s"
+    [shard-precreation]
       enabled = true
-      check_interval = "10m0s"
-      advance_period = "30m0s"
+      check-interval = "10m0s"
+      advance-period = "30m0s"
     [monitor]
-      store_enabled = true
-      store_database = "_internal"
-      store_interval = "10s"
+      store-enabled = true
+      store-database = "-internal"
+      store-interval = "10s"
     [subscriber]
       enabled = true
-      http_timeout = "30s"
-      insecure_skip_verify = false
-      ca_certs = ""
-      write_concurrency = 40
-      write_buffer_size = 1000
+      http-timeout = "30s"
+      insecure-skip-verify = false
+      ca-certs = ""
+      write-concurrency = 40
+      write-buffer-size = 1000
     [http]
       enabled = true
-      bind_address = 8086
-      auth_enabled = false
-      log_enabled = true
-      write_tracing = false
-      pprof_enabled = true
-      https_enabled = false
-      https_certificate = "/etc/ssl/influxdb.pem"
-      https_private_key = ""
-      max_row_limit = 10000
-      max_connection_limit = 0
-      shared_secret = "beetlejuicebeetlejuicebeetlejuice"
+      bind-address = ":8086"
+      auth-enabled = false
+      log-enabled = true
+      write-tracing = false
+      pprof-enabled = true
+      https-enabled = false
+      https-certificate = "/etc/ssl/influxdb.pem"
+      https-private-key = ""
+      max-row-limit = 10000
+      max-connection-limit = 0
+      shared-secret = "beetlejuicebeetlejuicebeetlejuice"
       realm = "InfluxDB"
-      unix_socket_enabled = false
-      bind_socket = "/var/run/influxdb.sock"
+      unix-socket-enabled = false
+      bind-socket = "/var/run/influxdb.sock"
     [[graphite]]
       enabled = false
-      bind_address = 2003
+      bind-address = 2003
       database = "graphite"
-      retention_policy = "autogen"
+      retention-policy = "autogen"
       protocol = "tcp"
-      batch_size = 5000
-      batch_pending = 10
-      batch_timeout = "1s"
-      consistency_level = "one"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "1s"
+      consistency-level = "one"
       separator = "."
-      udp_read_buffer = 0
+      udp-read-buffer = 0
     [[collectd]]
       enabled = false
-      bind_address = 25826
+      bind-address = ":25826"
       database = "collectd"
-      retention_policy = "autogen"
-      batch_size = 5000
-      batch_pending = 10
-      batch_timeout = "10s"
-      read_buffer = 0
+      retention-policy = "autogen"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "10s"
+      read-buffer = 0
       typesdb = "/usr/share/collectd/types.db"
-      security_level = "none"
-      auth_file = "/etc/collectd/auth_file"
+      security-level = "none"
+      auth-file = "/etc/collectd/auth-file"
     [[opentsdb]]
       enabled = false
-      bind_address = 4242
+      bind-address = ":4242"
       database = "opentsdb"
-      retention_policy = "autogen"
-      consistency_level = "one"
-      tls_enabled = false
+      retention-policy = "autogen"
+      consistency-level = "one"
+      tls-enabled = false
       certificate = "/etc/ssl/influxdb.pem"
-      batch_size = 1000
-      batch_pending = 5
-      batch_timeout = "1s"
-      log_point_errors = true
+      batch-size = 1000
+      batch-pending = 5
+      batch-timeout = "1s"
+      log-point-errors = true
     [[udp]]
       enabled = false
-      bind_address = 8089
+      bind-address = ":8089"
       database = "udp"
-      retention_policy = "autogen"
-      batch_size = 5000
-      batch_pending = 10
-      read_buffer = 0
-      batch_timeout = "1s"
+      retention-policy = "autogen"
+      batch-size = 5000
+      batch-pending = 10
+      read-buffer = 0
+      batch-timeout = "1s"
       precision = "ns"
-    [continuous_queries]
-      log_enabled = true
+    [continuous-queries]
+      log-enabled = true
       enabled = true
-      run_interval = "1s"
+      run-interval = "1s"
 ---
 apiVersion: influxdata.com/v1alpha1
 kind: Influxdb

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -58,7 +58,7 @@ spec:
       containers:
         - name: influxdata-operator
           # Replace this with the built image name
-          image: REPLACE-IMAGE
+          image: REPLACE_IMAGE
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -6,113 +6,113 @@ metadata:
     app: influxdb
 data:
   influxdb.conf: |+
-    reporting_disabled = false
-    bind_address = "127.0.0.1:8088"
-    storage_directory = "/var/lib/influxdb"
+    reporting-disabled = false
+    bind-address = "127.0.0.1:8088"
+    storage-directory = "/var/lib/influxdb"
     [meta]
       dir = "/var/lib/influxdb/meta"
-      retention_autocreate = true
-      logging_enabled = true
+      retention-autocreate = true
+      logging-enabled = true
     [data]
       dir = "/var/lib/influxdb/data"
       wal-dir = "/var/lib/influxdb/wal"
-      query_log_enabled = true
-      cache_max_memory_size = 1073741824
-      cache_snapshot_memory_size = 26214400
-      cache_snapshot_write_cold_duration = "10m0s"
-      compact_full_write_cold_duration = "4h0m0s"
-      max_series_per_database = 1000000
-      max_values_per_tag = 100000
-      trace_logging_enabled = false
+      query-log-enabled = true
+      cache-max-memory-size = 1073741824
+      cache-snapshot-memory-size = 26214400
+      cache-snapshot-write-cold-duration = "10m0s"
+      compact-full-write-cold-duration = "4h0m0s"
+      max-series-per-database = 1000000
+      max-values-per-tag = 100000
+      trace-logging-enabled = false
     [coordinator]
-      write_timeout = "10s"
-      max_concurrent_queries = 0
-      query_timeout = "0s"
-      log_queries_after = "0s"
-      max_select_point = 0
-      max_select_series = 0
-      max_select_buckets = 0
+      write-timeout = "10s"
+      max-concurrent-queries = 0
+      query-timeout = "0s"
+      log-queries-after = "0s"
+      max-select-point = 0
+      max-select-series = 0
+      max-select-buckets = 0
     [retention]
       enabled = true
-      check_interval = "30m0s"
-    [shard_precreation]
+      check-interval = "30m0s"
+    [shard-precreation]
       enabled = true
-      check_interval = "10m0s"
-      advance_period = "30m0s"
+      check-interval = "10m0s"
+      advance-period = "30m0s"
     [monitor]
-      store_enabled = true
-      store_database = "_internal"
-      store_interval = "10s"
+      store-enabled = true
+      store-database = "-internal"
+      store-interval = "10s"
     [subscriber]
       enabled = true
-      http_timeout = "30s"
-      insecure_skip_verify = false
-      ca_certs = ""
-      write_concurrency = 40
-      write_buffer_size = 1000
+      http-timeout = "30s"
+      insecure-skip-verify = false
+      ca-certs = ""
+      write-concurrency = 40
+      write-buffer-size = 1000
     [http]
       enabled = true
-      bind_address = 8086
-      auth_enabled = false
-      log_enabled = true
-      write_tracing = false
-      pprof_enabled = true
-      https_enabled = false
-      https_certificate = "/etc/ssl/influxdb.pem"
-      https_private_key = ""
-      max_row_limit = 10000
-      max_connection_limit = 0
-      shared_secret = "beetlejuicebeetlejuicebeetlejuice"
+      bind-address = ":8086"
+      auth-enabled = false
+      log-enabled = true
+      write-tracing = false
+      pprof-enabled = true
+      https-enabled = false
+      https-certificate = "/etc/ssl/influxdb.pem"
+      https-private-key = ""
+      max-row-limit = 10000
+      max-connection-limit = 0
+      shared-secret = "beetlejuicebeetlejuicebeetlejuice"
       realm = "InfluxDB"
-      unix_socket_enabled = false
-      bind_socket = "/var/run/influxdb.sock"
+      unix-socket-enabled = false
+      bind-socket = "/var/run/influxdb.sock"
     [[graphite]]
       enabled = false
-      bind_address = 2003
+      bind-address = ":2003"
       database = "graphite"
-      retention_policy = "autogen"
+      retention-policy = "autogen"
       protocol = "tcp"
-      batch_size = 5000
-      batch_pending = 10
-      batch_timeout = "1s"
-      consistency_level = "one"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "1s"
+      consistency-level = "one"
       separator = "."
-      udp_read_buffer = 0
+      udp-read-buffer = 0
     [[collectd]]
       enabled = false
-      bind_address = 25826
+      bind-address = ":25826"
       database = "collectd"
-      retention_policy = "autogen"
-      batch_size = 5000
-      batch_pending = 10
-      batch_timeout = "10s"
-      read_buffer = 0
+      retention-policy = "autogen"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "10s"
+      read-buffer = 0
       typesdb = "/usr/share/collectd/types.db"
-      security_level = "none"
-      auth_file = "/etc/collectd/auth_file"
+      security-level = "none"
+      auth-file = "/etc/collectd/auth-file"
     [[opentsdb]]
       enabled = false
-      bind_address = 4242
+      bind-address = ":4242"
       database = "opentsdb"
-      retention_policy = "autogen"
-      consistency_level = "one"
-      tls_enabled = false
+      retention-policy = "autogen"
+      consistency-level = "one"
+      tls-enabled = false
       certificate = "/etc/ssl/influxdb.pem"
-      batch_size = 1000
-      batch_pending = 5
-      batch_timeout = "1s"
-      log_point_errors = true
+      batch-size = 1000
+      batch-pending = 5
+      batch-timeout = "1s"
+      log-point-errors = true
     [[udp]]
       enabled = false
-      bind_address = 8089
+      bind-address = ":8089"
       database = "udp"
-      retention_policy = "autogen"
-      batch_size = 5000
-      batch_pending = 10
-      read_buffer = 0
-      batch_timeout = "1s"
+      retention-policy = "autogen"
+      batch-size = 5000
+      batch-pending = 10
+      read-buffer = 0
+      batch-timeout = "1s"
       precision = "ns"
-    [continuous_queries]
-      log_enabled = true
+    [continuous-queries]
+      log-enabled = true
       enabled = true
-      run_interval = "1s"
+      run-interval = "1s"

--- a/deploy/crds/influxdata_v1alpha1_influxdb_cr.yaml
+++ b/deploy/crds/influxdata_v1alpha1_influxdb_cr.yaml
@@ -143,116 +143,116 @@ metadata:
     app: influxdb
 data:
   influxdb.conf: |+
-    reporting_disabled = false
-    bind_address = "127.0.0.1:8088"
-    storage_directory = "/var/lib/influxdb"
+    reporting-disabled = false
+    bind-address = "127.0.0.1:8088"
+    storage-directory = "/var/lib/influxdb"
     [meta]
       dir = "/var/lib/influxdb/meta"
-      retention_autocreate = true
-      logging_enabled = true
+      retention-autocreate = true
+      logging-enabled = true
     [data]
       dir = "/var/lib/influxdb/data"
       wal-dir = "/var/lib/influxdb/wal"
-      query_log_enabled = true
-      cache_max_memory_size = 1073741824
-      cache_snapshot_memory_size = 26214400
-      cache_snapshot_write_cold_duration = "10m0s"
-      compact_full_write_cold_duration = "4h0m0s"
-      max_series_per_database = 1000000
-      max_values_per_tag = 100000
-      trace_logging_enabled = false
+      query-log-enabled = true
+      cache-max-memory-size = 1073741824
+      cache-snapshot-memory-size = 26214400
+      cache-snapshot-write-cold-duration = "10m0s"
+      compact-full-write-cold-duration = "4h0m0s"
+      max-series-per-database = 1000000
+      max-values-per-tag = 100000
+      trace-logging-enabled = false
     [coordinator]
-      write_timeout = "10s"
-      max_concurrent_queries = 0
-      query_timeout = "0s"
-      log_queries_after = "0s"
-      max_select_point = 0
-      max_select_series = 0
-      max_select_buckets = 0
+      write-timeout = "10s"
+      max-concurrent-queries = 0
+      query-timeout = "0s"
+      log-queries-after = "0s"
+      max-select-point = 0
+      max-select-series = 0
+      max-select-buckets = 0
     [retention]
       enabled = true
-      check_interval = "30m0s"
-    [shard_precreation]
+      check-interval = "30m0s"
+    [shard-precreation]
       enabled = true
-      check_interval = "10m0s"
-      advance_period = "30m0s"
+      check-interval = "10m0s"
+      advance-period = "30m0s"
     [monitor]
-      store_enabled = true
-      store_database = "_internal"
-      store_interval = "10s"
+      store-enabled = true
+      store-database = "-internal"
+      store-interval = "10s"
     [subscriber]
       enabled = true
-      http_timeout = "30s"
-      insecure_skip_verify = false
-      ca_certs = ""
-      write_concurrency = 40
-      write_buffer_size = 1000
+      http-timeout = "30s"
+      insecure-skip-verify = false
+      ca-certs = ""
+      write-concurrency = 40
+      write-buffer-size = 1000
     [http]
       enabled = true
-      bind_address = 8086
-      auth_enabled = false
-      log_enabled = true
-      write_tracing = false
-      pprof_enabled = true
-      https_enabled = false
-      https_certificate = "/etc/ssl/influxdb.pem"
-      https_private_key = ""
-      max_row_limit = 10000
-      max_connection_limit = 0
-      shared_secret = "beetlejuicebeetlejuicebeetlejuice"
+      bind-address = ":8086"
+      auth-enabled = false
+      log-enabled = true
+      write-tracing = false
+      pprof-enabled = true
+      https-enabled = false
+      https-certificate = "/etc/ssl/influxdb.pem"
+      https-private-key = ""
+      max-row-limit = 10000
+      max-connection-limit = 0
+      shared-secret = "beetlejuicebeetlejuicebeetlejuice"
       realm = "InfluxDB"
-      unix_socket_enabled = false
-      bind_socket = "/var/run/influxdb.sock"
+      unix-socket-enabled = false
+      bind-socket = "/var/run/influxdb.sock"
     [[graphite]]
       enabled = false
-      bind_address = 2003
+      bind-address = ":2003"
       database = "graphite"
-      retention_policy = "autogen"
+      retention-policy = "autogen"
       protocol = "tcp"
-      batch_size = 5000
-      batch_pending = 10
-      batch_timeout = "1s"
-      consistency_level = "one"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "1s"
+      consistency-level = "one"
       separator = "."
-      udp_read_buffer = 0
+      udp-read-buffer = 0
     [[collectd]]
       enabled = false
-      bind_address = 25826
+      bind-address = ":25826"
       database = "collectd"
-      retention_policy = "autogen"
-      batch_size = 5000
-      batch_pending = 10
-      batch_timeout = "10s"
-      read_buffer = 0
+      retention-policy = "autogen"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "10s"
+      read-buffer = 0
       typesdb = "/usr/share/collectd/types.db"
-      security_level = "none"
-      auth_file = "/etc/collectd/auth_file"
+      security-level = "none"
+      auth-file = "/etc/collectd/auth-file"
     [[opentsdb]]
       enabled = false
-      bind_address = 4242
+      bind-address = ":4242"
       database = "opentsdb"
-      retention_policy = "autogen"
-      consistency_level = "one"
-      tls_enabled = false
+      retention-policy = "autogen"
+      consistency-level = "one"
+      tls-enabled = false
       certificate = "/etc/ssl/influxdb.pem"
-      batch_size = 1000
-      batch_pending = 5
-      batch_timeout = "1s"
-      log_point_errors = true
+      batch-size = 1000
+      batch-pending = 5
+      batch-timeout = "1s"
+      log-point-errors = true
     [[udp]]
       enabled = false
-      bind_address = 8089
+      bind-address = ":8089"
       database = "udp"
-      retention_policy = "autogen"
-      batch_size = 5000
-      batch_pending = 10
-      read_buffer = 0
-      batch_timeout = "1s"
+      retention-policy = "autogen"
+      batch-size = 5000
+      batch-pending = 10
+      read-buffer = 0
+      batch-timeout = "1s"
       precision = "ns"
-    [continuous_queries]
-      log_enabled = true
+    [continuous-queries]
+      log-enabled = true
       enabled = true
-      run_interval = "1s"
+      run-interval = "1s"
 ---
 apiVersion: influxdata.com/v1alpha1
 kind: Influxdb


### PR DESCRIPTION
Default config values contained underscores and are ignored by influx. This can be misleading.