### PR TITLE
fix the invalid configuration values in default influxdb config

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -178,7 +178,7 @@ data:
       advance-period = "30m0s"
     [monitor]
       store-enabled = true
-      store-database = "-internal"
+      store-database = "_internal"
       store-interval = "10s"
     [subscriber]
       enabled = true
@@ -205,7 +205,7 @@ data:
       bind-socket = "/var/run/influxdb.sock"
     [[graphite]]
       enabled = false
-      bind-address = 2003
+      bind-address = ":2003"
       database = "graphite"
       retention-policy = "autogen"
       protocol = "tcp"
@@ -226,7 +226,7 @@ data:
       read-buffer = 0
       typesdb = "/usr/share/collectd/types.db"
       security-level = "none"
-      auth-file = "/etc/collectd/auth-file"
+      auth-file = "/etc/collectd/auth_file"
     [[opentsdb]]
       enabled = false
       bind-address = ":4242"

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -41,7 +41,7 @@ data:
       advance-period = "30m0s"
     [monitor]
       store-enabled = true
-      store-database = "-internal"
+      store-database = "_internal"
       store-interval = "10s"
     [subscriber]
       enabled = true
@@ -89,7 +89,7 @@ data:
       read-buffer = 0
       typesdb = "/usr/share/collectd/types.db"
       security-level = "none"
-      auth-file = "/etc/collectd/auth-file"
+      auth-file = "/etc/collectd/auth_file"
     [[opentsdb]]
       enabled = false
       bind-address = ":4242"

--- a/deploy/crds/influxdata_v1alpha1_influxdb_cr.yaml
+++ b/deploy/crds/influxdata_v1alpha1_influxdb_cr.yaml
@@ -178,7 +178,7 @@ data:
       advance-period = "30m0s"
     [monitor]
       store-enabled = true
-      store-database = "-internal"
+      store-database = "_internal"
       store-interval = "10s"
     [subscriber]
       enabled = true
@@ -226,7 +226,7 @@ data:
       read-buffer = 0
       typesdb = "/usr/share/collectd/types.db"
       security-level = "none"
-      auth-file = "/etc/collectd/auth-file"
+      auth-file = "/etc/collectd/auth_file"
     [[opentsdb]]
       enabled = false
       bind-address = ":4242"


### PR DESCRIPTION
- https://github.com/influxdata/influxdata-operator/pull/5

 has a few hiccups on  invalid configuration values, which makes the influxdb-0 pod into a state of CrashLoopBackoff. The root cause is `bind-address = 2003` under graphite is invalid. 
- There are other values such as `-internal` and `auth-file` should use underscore instead. 

Once the fixes are in, the influxdb-0 pod runs again. 

Thanks